### PR TITLE
Fix value for devkmsg proc not apply

### DIFF
--- a/kernel/printk/printk.c
+++ b/kernel/printk/printk.c
@@ -114,13 +114,13 @@ static int __control_devkmsg(char *str)
 	if (!str)
 		return -EINVAL;
 
-	if (!strncmp(str, "on", 2)) {
+	if (strncmp(str, "on", 2)==0) {
 		devkmsg_log = DEVKMSG_LOG_MASK_ON;
 		return 2;
-	} else if (!strncmp(str, "off", 3)) {
+	} else if (strncmp(str, "off", 3)==0) {
 		devkmsg_log = DEVKMSG_LOG_MASK_OFF;
 		return 3;
-	} else if (!strncmp(str, "ratelimit", 9)) {
+	} else if (strncmp(str, "ratelimit", 9)==0) {
 		devkmsg_log = DEVKMSG_LOG_MASK_DEFAULT;
 		return 9;
 	}


### PR DESCRIPTION
The patch is in the upstream but not applied in almost all android kernels..
Source: https://lore.kernel.org/lkml/1485522706-18852-1-git-send-email-rabin.vincent@axis.com
Here keep the original function and check return value instead.