### PR TITLE
Revert "msm: vidc: fix msm_comm_get_vidc_buffer fd race issue"

### DIFF
--- a/drivers/media/platform/msm/vidc/msm_vidc_common.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc_common.c
@@ -6636,24 +6636,25 @@ struct msm_vidc_buffer *msm_comm_get_vidc_buffer(struct msm_vidc_inst *inst,
 	struct vb2_v4l2_buffer *vbuf;
 	struct vb2_buffer *vb;
 	unsigned long dma_planes[VB2_MAX_PLANES] = {0};
-	struct msm_vidc_buffer *mbuf = NULL;
+	struct msm_vidc_buffer *mbuf;
 	bool found = false;
-	int i = 0, planes = 0;
+	int i;
 
 	if (!inst || !vb2) {
 		dprintk(VIDC_ERR, "%s: invalid params\n", __func__);
 		return NULL;
 	}
 
-	for (planes = 0; planes < vb2->num_planes; planes++) {
+	for (i = 0; i < vb2->num_planes; i++) {
 		/*
 		 * always compare dma_buf addresses which is guaranteed
 		 * to be same across the processes (duplicate fds).
 		 */
-		dma_planes[planes] = (unsigned long)msm_smem_get_dma_buf(
-				vb2->planes[planes].m.fd);
-		if (!dma_planes[planes])
-			goto put_ref;
+		dma_planes[i] = (unsigned long)msm_smem_get_dma_buf(
+				vb2->planes[i].m.fd);
+		if (!dma_planes[i])
+			return NULL;
+		msm_smem_put_dma_buf((struct dma_buf *)dma_planes[i]);
 	}
 
 	mutex_lock(&inst->registeredbufs.lock);
@@ -6756,21 +6757,27 @@ struct msm_vidc_buffer *msm_comm_get_vidc_buffer(struct msm_vidc_inst *inst,
 	if (!found)
 		list_add_tail(&mbuf->list, &inst->registeredbufs.list);
 
-exit:
-	if (rc == -EEXIST) {
-		print_vidc_buffer(VIDC_DBG, "qbuf upon rbr", inst, mbuf);
-	} else if (rc) {
-		dprintk(VIDC_ERR, "%s: rc %d\n", __func__, rc);
-		msm_comm_unmap_vidc_buffer(inst, mbuf);
-		if (!found)
-			kref_put_mbuf(mbuf);
-	}
 	mutex_unlock(&inst->registeredbufs.lock);
-put_ref:
-	while (planes)
-		msm_smem_put_dma_buf((struct dma_buf *)dma_planes[--planes]);
 
-	return rc ? ERR_PTR(rc) : mbuf;
+	/*
+	 * Return mbuf if decode batching is enabled as this buffer
+	 * may trigger queuing full batch to firmware, also this buffer
+	 * will not be queued to firmware while full batch queuing,
+	 * it will be queued when rbr event arrived from firmware.
+	 */
+	if (rc == -EEXIST && !inst->batch.enable)
+		return ERR_PTR(rc);
+
+	return mbuf;
+
+exit:
+	dprintk(VIDC_ERR, "%s: rc %d\n", __func__, rc);
+	msm_comm_unmap_vidc_buffer(inst, mbuf);
+	if (!found)
+		kref_put_mbuf(mbuf);
+	mutex_unlock(&inst->registeredbufs.lock);
+
+	return ERR_PTR(rc);
 }
 
 void msm_comm_put_vidc_buffer(struct msm_vidc_inst *inst,

--- a/scripts/Makefile.host
+++ b/scripts/Makefile.host
@@ -96,7 +96,7 @@ hostcxx_flags  = -Wp,-MD,$(depfile) $(__hostcxx_flags)
 # Create executable from a single .c file
 # host-csingle -> Executable
 quiet_cmd_host-csingle 	= HOSTCC  $@
-      cmd_host-csingle	= $(HOSTCC) $(hostc_flags) -o $@ $< \
+      cmd_host-csingle	= $(HOSTCC) $(hostc_flags) $(HOSTLDFLAGS) -o $@ $< \
 	  	$(HOST_LOADLIBES) $(HOSTLOADLIBES_$(@F))
 $(host-csingle): $(obj)/%: $(src)/%.c FORCE
 	$(call if_changed_dep,host-csingle)


### PR DESCRIPTION
This reverts commit ec47947008807b7c6247ddf9ecb50a54d071b917.

Seems to have broken some twitter/webm videos.